### PR TITLE
Fix range check for ChuckSomeDice()

### DIFF
--- a/src/runtime/callable/builtin.rs
+++ b/src/runtime/callable/builtin.rs
@@ -192,7 +192,7 @@ impl AussieCallable for Rand {
             }
         };
 
-        if start > end {
+        if start >= end {
             return Err(RuntimeError::General(
                 "OI MATE, CAN YA FUCKIN' COUNT?? START MUST BE LESS THAN END!!".into(),
             )


### PR DESCRIPTION
Fixes #41 

It turns out the error wasn't about floats per se -- `ChuckSomeDice(0, 0)` would cause the same panic, while `ChuckSomeDice(0, 1.5)` wouldn't.